### PR TITLE
Asking for plugin path to create config file before syncing

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -22,11 +22,18 @@ cd "$MY_PATH"
 file=scripts.conf
 if [[ ! -e "$file" ]]
 then
+  DEFAULT_QGIS_PLUGIN_PATH="$HOME/.local/share/QGIS/QGIS3/profiles/default/python/plugins"
+  echo "¿Dónde está la ruta destino de tu plugin?: [ $DEFAULT_QGIS_PLUGIN_PATH ]"
+  read QGIS_PLUGIN_PATH
+  if [ "$QGIS_PLUGIN_PATH" = "" ]
+  then
+    QGIS_PLUGIN_PATH="$DEFAULT_QGIS_PLUGIN_PATH"
+  fi
   tee "$file" << EOF
 # Establezca valores NOMBRE=VALOR sin espacios en el igual
-ASISTENTE_LADM_DIR="/home/jorge/bin/QGIS/build-master/output/python/plugins/Asistente-LADM_COL/"
+ASISTENTE_LADM_DIR="$QGIS_PLUGIN_PATH"
 EOF
-  echo "Modifique el archivo $MY_PATH/$file a su conveniencia."
+  echo "Se ha modificado el archivo de configuración $MY_PATH/$file."
 fi
 
 source $file


### PR DESCRIPTION
This script is useful in case of the repository changes must be synced to probe in qgis, only copy and pasting it's so slowly. Other use is realize things in repo and plugin path at the same time (like execute unit tests in docker and test in qgis).

Example of first use:
```
 $ ./sync.sh 
¿Where are your plugin?: [ /home/jorge/.local/share/QGIS/QGIS3/profiles/default/python/plugins ]
/home/jorge/bin/QGIS/build-master/output/python/plugins/Asistente-LADM_COL
# Establezca valores NOMBRE=VALOR sin espacios en el igual
ASISTENTE_LADM_DIR="/home/jorge/bin/QGIS/build-master/output/python/plugins/Asistente-LADM_COL"
Se ha modificado el archivo de configuración /home/jorge/workspace/Asistente-LADM_COL/scripts/scripts.conf.
Sincronizando /home/jorge/bin/QGIS/build-master/output/python/plugins/Asistente-LADM_COL
sending incremental file list
./
...
```
Later use with config:
```
$ watch -n 1 ./sync.sh
Every 1,0s: ./sync.sh                          ulises: Mon Mar 12 22:28:38 2018

Sincronizando /home/jorge/bin/QGIS/build-master/output/python/plugins/Asistente-
LADM_COL
sending incremental file list

sent 4,363 bytes  received 31 bytes  8,788.00 bytes/sec
total size is 1,548,359  speedup is 352.38
...
```