### PR TITLE
Fix field port empty in settings dialog

### DIFF
--- a/asistente_ladm_col/gui/settings_dialog.py
+++ b/asistente_ladm_col/gui/settings_dialog.py
@@ -107,7 +107,7 @@ class SettingsDialog(QDialog, DIALOG_UI):
         """
         dict_conn = dict()
         dict_conn['host'] = self.txt_pg_host.text().strip() or 'localhost'
-        dict_conn['port'] = self.txt_pg_port.text().strip() or 5432
+        dict_conn['port'] = self.txt_pg_port.text().strip() or '5432'
         dict_conn['database'] = self.txt_pg_database.text().strip()
         dict_conn['schema'] = self.txt_pg_schema.text().strip() or 'public'
         dict_conn['user'] = self.txt_pg_user.text().strip()


### PR DESCRIPTION
Empty value for port generate errors in the plugin execution, this is because incorrect type in automatic assignation for this value.