### PR TITLE
Simple adjustments to QgsField data type for ID fields

### DIFF
--- a/asistente_ladm_col/utils/quality.py
+++ b/asistente_ladm_col/utils/quality.py
@@ -150,7 +150,7 @@ class QualityUtils(QObject):
                                      differences_layer_name, "memory")
 
         data_provider = error_layer.dataProvider()
-        data_provider.addAttributes([QgsField('plot_id', QVariant.String)])
+        data_provider.addAttributes([QgsField('plot_id', QVariant.Int)])
         error_layer.updateFields()
 
         features = []
@@ -272,7 +272,7 @@ class QualityUtils(QObject):
                                      differences_layer_name, "memory")
 
         data_provider = error_layer.dataProvider()
-        data_provider.addAttributes([QgsField('boundary_id', QVariant.String)])
+        data_provider.addAttributes([QgsField('boundary_id', QVariant.Int)])
         error_layer.updateFields()
 
         features = []
@@ -313,7 +313,7 @@ class QualityUtils(QObject):
                                      QCoreApplication.translate("QGISUtils", "Overlapping polygons in {}")
                                                                 .format(polygon_layer_name), "memory")
         data_provider = error_layer.dataProvider()
-        data_provider.addAttributes([QgsField("polygon_id", QVariant.String),
+        data_provider.addAttributes([QgsField("polygon_id", QVariant.Int),
                                      QgsField("overlapping_ids", QVariant.String),
                                      QgsField("count_parts", QVariant.Int)])
         error_layer.updateFields()


### PR DESCRIPTION
The data type was changed for some QgsField from String to Int (When the field is ID)
