### PR TITLE
[gui] support associate building units to parcel

### DIFF
--- a/asistente_ladm_col/config/table_mapping_config.py
+++ b/asistente_ladm_col/config/table_mapping_config.py
@@ -234,7 +234,7 @@ LAYER_CONSTRAINTS = {
                           'WHEN "{parcel_type}" IS NOT NULL AND num_selected(\'{layer}\') = 0 THEN \n("{parcel_type}" != \'PropiedadHorizontal.UnidadPredial\')\n'
                           'ELSE True\n'
                           'END'.format(parcel_type=PARCEL_TYPE_FIELD, layer=BUILDING_UNIT_TABLE),
-            'description': 'Si el tipo de predio es Propiedad Horizontal, debes elegir unicamente la opción {parcel_type_field}; en otro caso puedes seleccionar cualquier otra opción del listado.'.format(parcel_type_field=PARCEL_TYPE_PH_OPTION)
+            'description': 'Si el tipo de predio es Propiedad Horizontal, debes elegir únicamente la opción {parcel_type_field}; en otro caso puedes seleccionar cualquier otra opción del listado.'.format(parcel_type_field=PARCEL_TYPE_PH_OPTION)
         }
     }
 }

--- a/asistente_ladm_col/config/table_mapping_config.py
+++ b/asistente_ladm_col/config/table_mapping_config.py
@@ -134,6 +134,7 @@ LEGAL_PARTY_TABLE = "interesado_juridico"
 PROPERTY PARCEL TABLE
 """
 PARCEL_TYPE_FIELD = "tipo"
+PARCEL_TYPE_PH_OPTION = "PropiedadHorizontal.UnidadPredial"
 
 
 NAMESPACE_PREFIX = {
@@ -233,7 +234,7 @@ LAYER_CONSTRAINTS = {
                           'WHEN "{parcel_type}" IS NOT NULL AND num_selected(\'{layer}\') = 0 THEN \n("{parcel_type}" != \'PropiedadHorizontal.UnidadPredial\')\n'
                           'ELSE True\n'
                           'END'.format(parcel_type=PARCEL_TYPE_FIELD, layer=BUILDING_UNIT_TABLE),
-            'description': ''
+            'description': 'Si el tipo de predio es Propiedad Horizontal, debes elegir unicamente la opción {parcel_type_field}; en otro caso puedes seleccionar cualquier otra opción del listado.'.format(parcel_type_field=PARCEL_TYPE_PH_OPTION)
         }
     }
 }

--- a/asistente_ladm_col/config/table_mapping_config.py
+++ b/asistente_ladm_col/config/table_mapping_config.py
@@ -130,6 +130,11 @@ NUCLEAR_FAMILY_TABLE = "nucleofamiliar"
 NATURAL_PARTY_TABLE = "interesado_natural"
 LEGAL_PARTY_TABLE = "interesado_juridico"
 
+"""
+PROPERTY PARCEL TABLE
+"""
+PARCEL_TYPE_FIELD = "tipo"
+
 
 NAMESPACE_PREFIX = {
     ADMINISTRATIVE_SOURCE_TABLE: 's',
@@ -219,6 +224,16 @@ LAYER_CONSTRAINTS = {
         PRC_PUBLIC_PARCEL_TYPE_FIELD: {
             'expression': 'CASE WHEN "{prc_ptf}" IS NOT NULL THEN\n(strpos("{prc_ptf}", \'Privado.\') != 0 AND "{prc_pptf}" IS NULL) OR (strpos("{prc_ptf}", \'Publico.\') != 0 AND "{prc_pptf}" IS NOT NULL)\nELSE True\nEND'.format(prc_ptf=PRC_PARCEL_TYPE_FIELD, prc_pptf=PRC_PUBLIC_PARCEL_TYPE_FIELD),
             'description': 'Si el tipo de predio es Público, debes elegir un valor de este listado; pero si el tipo de predio es Privado, no debes seleccionar ningún valor de este listado.'
+        }
+    },
+    PARCEL_TABLE: {
+        PARCEL_TYPE_FIELD: {
+            'expression': 'CASE\n'
+                          'WHEN "{parcel_type}" IS NOT NULL AND num_selected(\'{layer}\') > 0 THEN \n("{parcel_type}" = \'PropiedadHorizontal.UnidadPredial\')\n'
+                          'WHEN "{parcel_type}" IS NOT NULL AND num_selected(\'{layer}\') = 0 THEN \n("{parcel_type}" != \'PropiedadHorizontal.UnidadPredial\')\n'
+                          'ELSE True\n'
+                          'END'.format(parcel_type=PARCEL_TYPE_FIELD, layer=BUILDING_UNIT_TABLE),
+            'description': ''
         }
     }
 }

--- a/asistente_ladm_col/gui/create_parcel_cadastre_wizard.py
+++ b/asistente_ladm_col/gui/create_parcel_cadastre_wizard.py
@@ -195,8 +195,6 @@ class CreateParcelCadastreWizard(QWizard, WIZARD_UI):
             self._parcel_layer.featureAdded.connect(self.call_parcel_commit)
             self._parcel_layer.committedFeaturesAdded.connect(partial(self.finish_parcel, None, None, building_unit_ids))
 
-
-            pass
         elif self._plot_layer.selectedFeatureCount() == 1 or self._building_layer.selectedFeatureCount() > 0:
             # Open Form
             self.iface.layerTreeView().setCurrentLayer(self._parcel_layer)

--- a/asistente_ladm_col/gui/create_parcel_cadastre_wizard.py
+++ b/asistente_ladm_col/gui/create_parcel_cadastre_wizard.py
@@ -176,17 +176,16 @@ class CreateParcelCadastreWizard(QWizard, WIZARD_UI):
         self.edit_parcel()
 
     def edit_parcel(self):
-
         if self._plot_layer.selectedFeatureCount() == 0 and self._building_layer.selectedFeatureCount() == 0 and self._building_unit_layer.selectedFeatureCount() == 0 :
             self.iface.messageBar().pushMessage("Asistente LADM_COL",
                 QCoreApplication.translate("CreateParcelCadastreWizard",
-                                           "Please select one Plot or at least one Building or at least one Building unit"),
+                                           "First select at least one Plot, one Building or one Building unit"),
                 Qgis.Warning)
             return
         elif self._plot_layer.selectedFeatureCount() > 1:
             self.iface.messageBar().pushMessage("Asistente LADM_COL",
                 QCoreApplication.translate("CreateParcelCadastreWizard",
-                                           "Please select only one Plot"),
+                                           "First select only one Plot"),
                 Qgis.Warning)
             return
 
@@ -195,7 +194,7 @@ class CreateParcelCadastreWizard(QWizard, WIZARD_UI):
         self._parcel_layer.startEditing()
         self.iface.actionAddFeature().trigger()
 
-        ## TODO: Show selection page when all three layers have selections
+        # TODO: Show selection page when all three layers have selections
         if self._building_unit_layer.selectedFeatureCount() > 0:
             # If building units are selected, there should be no plots or buildings.
             self._plot_layer.removeSelection()

--- a/asistente_ladm_col/ui/wiz_create_parcel_cadastre.ui
+++ b/asistente_ladm_col/ui/wiz_create_parcel_cadastre.ui
@@ -66,7 +66,8 @@
             <widget class="QRadioButton" name="rad_parcel_from_plot">
              <property name="text">
               <string>Entering data manually using a form
-(you need to select one Plot and/or Buildings before)</string>
+(you need to select one Plot and/or Buildings or 
+Building units before)</string>
              </property>
              <property name="checked">
               <bool>true</bool>
@@ -141,10 +142,10 @@
                  <height>16777215</height>
                 </size>
                </property>
-               <property name="allowEmptyLayer">
+               <property name="allowEmptyLayer" stdset="0">
                 <bool>true</bool>
                </property>
-               <property name="showCrs">
+               <property name="showCrs" stdset="0">
                 <bool>false</bool>
                </property>
               </widget>


### PR DESCRIPTION
Para PHs:

- [X] Al crear un predio se deben poder asociar (seleccionándolas en el mapa) unidades de construcción.
- [X] Si hay unidades de construcción seleccionadas, no deberían haber terrenos ni construcciones.
- [x] Si hay unidades de construcción seleccionadas, el nuevo predio solamente puede ser PH.

Fix #109