### PR TITLE
improve menu refresh and default connection creation

### DIFF
--- a/asistente_ladm_col/asistente_ladm_col_plugin.py
+++ b/asistente_ladm_col/asistente_ladm_col_plugin.py
@@ -85,7 +85,6 @@ class AsistenteLADMCOLPlugin(QObject):
         self.log = QgsApplication.messageLog()
         self._about_dialog = None
         self.toolbar = None
-        self._flag_menus_refreshed_at_load_time = False
 
     def initGui(self):
         # Set Menus

--- a/asistente_ladm_col/asistente_ladm_col_plugin.py
+++ b/asistente_ladm_col/asistente_ladm_col_plugin.py
@@ -369,9 +369,9 @@ class AsistenteLADMCOLPlugin(QObject):
     def refresh_menus(self, db):
         """
         Depending on the models avilable in the DB, some menus should appear or
-        dissapear from the GUI.
+        disappear from the GUI.
         """
-        res, msg = db.test_connection()
+        res, msg = db.test_connection() # The parser is specific for each new connection
         if res:
             model_parser = ModelParser(db)
             if model_parser.property_record_card_model_exists():

--- a/asistente_ladm_col/asistente_ladm_col_plugin.py
+++ b/asistente_ladm_col/asistente_ladm_col_plugin.py
@@ -366,7 +366,7 @@ class AsistenteLADMCOLPlugin(QObject):
 
         menu.deleteLater()
 
-    def refresh_menus(self, db, force=False):
+    def refresh_menus(self, db):
         """
         Depending on the models avilable in the DB, some menus should appear or
         dissapear from the GUI.

--- a/asistente_ladm_col/asistente_ladm_col_plugin.py
+++ b/asistente_ladm_col/asistente_ladm_col_plugin.py
@@ -118,11 +118,6 @@ class AsistenteLADMCOLPlugin(QObject):
                                self._help_action,
                                self._about_action])
 
-        # If project generator was loaded before Asistente
-        # LADM_COL, this call does its job, otherwise it won't and
-        # we will have to wait for the initializationCompleted
-        self.refresh_menus(self.get_db_connection())
-
         # Connections
         self._controlled_measurement_action.triggered.connect(self.show_dlg_controlled_measurement)
         self._load_layers_action.triggered.connect(self.load_layers_from_project_generator)
@@ -377,17 +372,13 @@ class AsistenteLADMCOLPlugin(QObject):
         Depending on the models avilable in the DB, some menus should appear or
         dissapear from the GUI.
         """
-        if not self._flag_menus_refreshed_at_load_time or force:
-            # The parser is specific for each new connection
-            res, msg = db.test_connection()
-            if res:
-                if not force:
-                    self._flag_menus_refreshed_at_load_time = True
-                model_parser = ModelParser(db)
-                if model_parser.property_record_card_model_exists():
-                    self.add_property_record_card_menu()
-                else:
-                    self.remove_property_record_card_menu()
+        res, msg = db.test_connection()
+        if res:
+            model_parser = ModelParser(db)
+            if model_parser.property_record_card_model_exists():
+                self.add_property_record_card_menu()
+            else:
+                self.remove_property_record_card_menu()
 
     def add_processing_models(self, provider_id):
         if not (provider_id == 'model' or provider_id is None):

--- a/asistente_ladm_col/gui/settings_dialog.py
+++ b/asistente_ladm_col/gui/settings_dialog.py
@@ -52,7 +52,7 @@ DIALOG_UI = get_ui_class('settings_dialog.ui')
 class SettingsDialog(QDialog, DIALOG_UI):
 
     cache_layers_and_relations_requested = pyqtSignal(DBConnector)
-    refresh_menus_requested = pyqtSignal(DBConnector, bool)
+    refresh_menus_requested = pyqtSignal(DBConnector)
     fetcher_task = None
 
     def __init__(self, iface=None, parent=None, qgis_utils=None):
@@ -122,7 +122,7 @@ class SettingsDialog(QDialog, DIALOG_UI):
             self.connection_is_dirty = False
             if self._db.test_connection()[0]:
                 self.cache_layers_and_relations_requested.emit(self._db)
-                self.refresh_menus_requested.emit(self._db) # force=True
+                self.refresh_menus_requested.emit(self._db)
 
         self.save_settings()
 

--- a/asistente_ladm_col/gui/settings_dialog.py
+++ b/asistente_ladm_col/gui/settings_dialog.py
@@ -122,7 +122,7 @@ class SettingsDialog(QDialog, DIALOG_UI):
             self.connection_is_dirty = False
             if self._db.test_connection()[0]:
                 self.cache_layers_and_relations_requested.emit(self._db)
-                self.refresh_menus_requested.emit(self._db, True) # force=True
+                self.refresh_menus_requested.emit(self._db) # force=True
 
         self.save_settings()
 

--- a/asistente_ladm_col/utils/qgis_utils.py
+++ b/asistente_ladm_col/utils/qgis_utils.py
@@ -125,7 +125,7 @@ class QGISUtils(QObject):
     create_progress_message_bar_emitted = pyqtSignal(str, QProgressBar)
     remove_error_group_requested = pyqtSignal()
     layer_symbology_changed = pyqtSignal(str) # layer id
-    refresh_menus_requested = pyqtSignal(DBConnector, bool)
+    refresh_menus_requested = pyqtSignal(DBConnector)
     message_emitted = pyqtSignal(str, int) # Message, level
     message_with_duration_emitted = pyqtSignal(str, int, int) # Message, level, duration
     message_with_button_load_layer_emitted = pyqtSignal(str, str, list, int) # Message, button text, [layer_name, geometry_type], level
@@ -189,11 +189,11 @@ class QGISUtils(QObject):
 
         self.clear_status_bar_emitted.emit()
 
-    def refresh_menus(self, db, force):
+    def refresh_menus(self, db):
         """
         Chain the SIGNAL request to other modules.
         """
-        self.refresh_menus_requested.emit(db, force)
+        self.refresh_menus_requested.emit(db)
 
     def get_related_layers(self, layer_names, already_loaded):
         """


### PR DESCRIPTION
In this branch the call to the function refres_menus is simplified (it was called twice) and the use of the variable _flag_menus_refreshed_at_load_time is suppressed