### PR TITLE
Show message java path

### DIFF
--- a/asistente_ladm_col/gui/reports.py
+++ b/asistente_ladm_col/gui/reports.py
@@ -171,8 +171,8 @@ class ReportGenerator():
             if 'JAVA_HOME' not in os.environ:
                 self.msg = QMessageBox()
                 self.msg.setIcon(QMessageBox.Information)
-                self.msg.setText(QCoreApplication.translate("ReportGenerator", "JAVA_HOME environment variable is not defined, please define and restart QGIS before generating annex 17."))
-                self.msg.setWindowTitle(QCoreApplication.translate("ReportGenerator", "JAVA_HOME environment variable is not defined"))
+                self.msg.setText(QCoreApplication.translate("ReportGenerator", "JAVA_HOME environment variable is not defined, please define it as an enviroment variable on Windows and restart QGIS before generating the annex 17."))
+                self.msg.setWindowTitle(QCoreApplication.translate("ReportGenerator", "JAVA_HOME not defined"))
                 self.msg.setStandardButtons(QMessageBox.Close)
                 self.msg.exec_()
                 return

--- a/asistente_ladm_col/gui/reports.py
+++ b/asistente_ladm_col/gui/reports.py
@@ -35,13 +35,13 @@ from qgis.PyQt.QtCore import (Qt,
                               QEventLoop,
                               QIODevice)
 from qgis.PyQt.QtWidgets import (QFileDialog,
+                                 QMessageBox,
                                  QProgressBar)
 from qgis.core import (QgsWkbTypes,
                        QgsDataSourceUri,
                        Qgis,
                        QgsNetworkContentFetcherTask,
                        QgsApplication)
-from ..utils.qgis_model_baker_utils import get_java_path_dir_from_qgis_model_baker
 
 from ..config.general_config import (TEST_SERVER,
                                      PLUGIN_NAME,
@@ -51,7 +51,6 @@ from ..config.table_mapping_config import (ID_FIELD,
                                            PLOT_TABLE, PARCEL_NUMBER_FIELD)
 from ..utils.qt_utils import (remove_readonly,
                               normalize_local_url)
-from ..gui.dlg_get_java_path import DialogGetJavaPath
 
 class ReportGenerator():
     def __init__(self, qgis_utils, ladm_data):
@@ -170,21 +169,13 @@ class ReportGenerator():
         # Check if JAVA_HOME path is set, otherwise use path from QGIS Model Baker
         if os.name == 'nt':
             if 'JAVA_HOME' not in os.environ:
-                java_path_dir = get_java_path_dir_from_qgis_model_baker()
-                if not java_path_dir:
-                    # Set Java Home
-                    get_java_path_dlg = DialogGetJavaPath()
-                    get_java_path_dlg.setModal(True)
-                    get_java_path_dlg.exec_()
-
-                    java_path_dir = get_java_path_dir_from_qgis_model_baker()
-                    if not java_path_dir:
-                        self.qgis_utils.message_emitted.emit(
-                            QCoreApplication.translate("ReportGenerator", "Please set JAVA_HOME path in QGIS Model Baker Settings or in your OS environmental variables."), Qgis.Warning)
-                        return
-                else:
-                    os.environ["JAVA_HOME"] = java_path_dir
-                    self.log.logMessage("The JAVA_HOME path has been set using QGIS Model Baker Settings for reports.", PLUGIN_NAME, Qgis.Info)
+                self.msg = QMessageBox()
+                self.msg.setIcon(QMessageBox.Critical)
+                self.msg.setText(QCoreApplication.translate("ReportGenerator", "Error: JAVA_HOME was not found"))
+                self.msg.setWindowTitle(QCoreApplication.translate("ReportGenerator", "JAVA_HOME environment variable is not defined, please define your environment variable and restart QGIS"))
+                self.msg.setStandardButtons(QMessageBox.Close)
+                self.msg.exec_()
+                return
 
         plot_layer = self.qgis_utils.get_layer(db, PLOT_TABLE, QgsWkbTypes.PolygonGeometry, load=True)
         if plot_layer is None:

--- a/asistente_ladm_col/gui/reports.py
+++ b/asistente_ladm_col/gui/reports.py
@@ -170,9 +170,9 @@ class ReportGenerator():
         if os.name == 'nt':
             if 'JAVA_HOME' not in os.environ:
                 self.msg = QMessageBox()
-                self.msg.setIcon(QMessageBox.Critical)
-                self.msg.setText(QCoreApplication.translate("ReportGenerator", "Error: JAVA_HOME was not found"))
-                self.msg.setWindowTitle(QCoreApplication.translate("ReportGenerator", "JAVA_HOME environment variable is not defined, please define your environment variable and restart QGIS"))
+                self.msg.setIcon(QMessageBox.Information)
+                self.msg.setText(QCoreApplication.translate("ReportGenerator", "JAVA_HOME environment variable is not defined, please define and restart QGIS before generating annex 17."))
+                self.msg.setWindowTitle(QCoreApplication.translate("ReportGenerator", "JAVA_HOME environment variable is not defined"))
                 self.msg.setStandardButtons(QMessageBox.Close)
                 self.msg.exec_()
                 return


### PR DESCRIPTION
When trying to generate annex 17 in Windows, the JAVA_HOME environment variable is checked. If it does not exist, an information message is displayed indicating that it is necessary to define it.