### PR TITLE
[gui] refresh menus when reload plugin

### DIFF
--- a/asistente_ladm_col/asistente_ladm_col_plugin.py
+++ b/asistente_ladm_col/asistente_ladm_col_plugin.py
@@ -151,6 +151,7 @@ class AsistenteLADMCOLPlugin(QObject):
         self._menu.addActions([self._settings_action,
                                self._help_action,
                                self._about_action])
+        self.refresh_menus(self.get_db_connection())
 
         # Connections
 


### PR DESCRIPTION
Solution when reload plugin and it did not show the other menus inside database.