### PR TITLE
[gui] Add "Go to import data../Go to create structure..." in data management

### DIFF
--- a/asistente_ladm_col/asistente_ladm_col_plugin.py
+++ b/asistente_ladm_col/asistente_ladm_col_plugin.py
@@ -1062,27 +1062,35 @@ class AsistenteLADMCOLPlugin(QObject):
         return self.conn_manager.get_db_connector_from_source(db_source=OFFICIAL_DB_SOURCE)
 
     @_qgis_model_baker_required
-    def show_dlg_import_schema(self):
+    def show_dlg_import_schema(self, *args, **kwargs):
         from .gui.qgis_model_baker.dlg_import_schema import DialogImportSchema
-        dlg = DialogImportSchema(self.iface, self.qgis_utils, self.conn_manager)
+
+        selected_models_import_schema = list()
+        for arg in args:
+            if isinstance(arg, list):
+                selected_models_import_schema = arg # Argument send by signal
+
+        dlg = DialogImportSchema(self.iface, self.qgis_utils, self.conn_manager, selected_models_import_schema)
         dlg.models_have_changed.connect(self.refresh_menus)
+        dlg.open_dlg_import_data.connect(self.show_dlg_import_data)
         dlg.exec_()
 
     @_qgis_model_baker_required
-    def show_dlg_import_data(self):
+    def show_dlg_import_data(self, *args, **kwargs):
         from .gui.qgis_model_baker.dlg_import_data import DialogImportData
         dlg = DialogImportData(self.iface, self.qgis_utils, self.conn_manager)
+        dlg.open_dlg_import_schema.connect(self.show_dlg_import_schema)
         dlg.exec_()
 
     @_qgis_model_baker_required
-    def show_dlg_export_data(self):
+    def show_dlg_export_data(self, *args, **kwargs):
         from .gui.qgis_model_baker.dlg_export_data import DialogExportData
         dlg = DialogExportData(self.iface, self.qgis_utils, self.conn_manager)
         dlg.exec_()
 
     @_qgis_model_baker_required
     @_activate_processing_plugin
-    def show_dlg_controlled_measurement(self):
+    def show_dlg_controlled_measurement(self, *args, **kwargs):
         dlg = ControlledMeasurementDialog(self.qgis_utils)
         dlg.exec_()
 

--- a/asistente_ladm_col/asistente_ladm_col_plugin.py
+++ b/asistente_ladm_col/asistente_ladm_col_plugin.py
@@ -169,7 +169,7 @@ class AsistenteLADMCOLPlugin(QObject):
                                self._about_action])
 
         # Connections
-        self._import_schema_action.triggered.connect(self.show_dlg_import_schema)
+        self._import_schema_action.triggered.connect(self.call_dlg_import_schema)
         self._import_data_action.triggered.connect(self.show_dlg_import_data)
         self._export_data_action.triggered.connect(self.show_dlg_export_data)
         self._controlled_measurement_action.triggered.connect(self.show_dlg_controlled_measurement)
@@ -1061,14 +1061,21 @@ class AsistenteLADMCOLPlugin(QObject):
     def get_official_db_connection(self):
         return self.conn_manager.get_db_connector_from_source(db_source=OFFICIAL_DB_SOURCE)
 
+    def call_dlg_import_schema(self, state):
+        """
+        Slot triggered by a menu
+        :param state: Checked state
+        :return:
+        """
+        self.show_dlg_import_schema(list())  # Parameter: No other models selected other than default models
+
     @_qgis_model_baker_required
     def show_dlg_import_schema(self, *args, **kwargs):
         from .gui.qgis_model_baker.dlg_import_schema import DialogImportSchema
 
         selected_models_import_schema = list()
-        for arg in args:
-            if isinstance(arg, list):
-                selected_models_import_schema = arg # Argument send by signal
+        if args:
+            selected_models_import_schema = args[0]  # Argument sent by signal
 
         dlg = DialogImportSchema(self.iface, self.qgis_utils, self.conn_manager, selected_models_import_schema)
         dlg.models_have_changed.connect(self.refresh_menus)

--- a/asistente_ladm_col/gui/qgis_model_baker/dlg_import_data.py
+++ b/asistente_ladm_col/gui/qgis_model_baker/dlg_import_data.py
@@ -66,7 +66,10 @@ DIALOG_UI = get_ui_class('qgis_model_baker/dlg_import_data.ui')
 
 
 class DialogImportData(QDialog, DIALOG_UI):
+
     open_dlg_import_schema = pyqtSignal(list) # selected models
+    BUTTON_NAME_IMPORT_DATA = QCoreApplication.translate("DialogImportData", "Import data")
+    BUTTON_NAME_GO_TO_CREATE_STRUCTURE = QCoreApplication.translate("DialogImportData",  "Go to Create Structure...")
 
     def __init__(self, iface, qgis_utils, conn_manager):
         QDialog.__init__(self)
@@ -113,7 +116,7 @@ class DialogImportData(QDialog, DIALOG_UI):
         self.buttonBox.clicked.connect(self.accepted_import_data)
         self.buttonBox.clear()
         self.buttonBox.addButton(QDialogButtonBox.Cancel)
-        self._accept_button = self.buttonBox.addButton(QCoreApplication.translate("DialogImportData", "Import data"), QDialogButtonBox.AcceptRole)
+        self._accept_button = self.buttonBox.addButton(self.BUTTON_NAME_IMPORT_DATA, QDialogButtonBox.AcceptRole)
         self.buttonBox.addButton(QDialogButtonBox.Help)
         self.buttonBox.helpRequested.connect(self.show_help)
 
@@ -122,12 +125,11 @@ class DialogImportData(QDialog, DIALOG_UI):
 
     def accepted_import_data(self, button):
         if self.buttonBox.buttonRole(button) == QDialogButtonBox.AcceptRole:
-            if button.text() == QCoreApplication.translate("DialogImportData",  "Import data"):
+            if button.text() == self.BUTTON_NAME_IMPORT_DATA:
                 self.accepted()
-            elif button.text() == QCoreApplication.translate("DialogImportData",  "Go to create structure..."):
-                self.close()  # Close import data dialog and open import schema dialog
-                # Emmit signal to open import schema dialog
-                self.open_dlg_import_schema.emit(self.get_ili_models())
+            elif button.text() == self.BUTTON_NAME_GO_TO_CREATE_STRUCTURE:
+                self.close()  # Close import data dialog
+                self.open_dlg_import_schema.emit(self.get_ili_models())  # Emit signal to open import schema dialog
 
     def update_connection_info(self):
         db_description = self.db.get_description_conn_string()
@@ -250,7 +252,7 @@ class DialogImportData(QDialog, DIALOG_UI):
 
         if not ili_models.issubset(db_models):
             message_error = "The XTF file to import does not have the same models as the target database schema. " \
-                            "Please create a schema also include the following missing schemas:\n\n * {}".format(" \n * ".join(sorted(ili_models.difference(db_models))))
+                            "Please create a schema that also includes the following missing modules:\n\n * {}".format(" \n * ".join(sorted(ili_models.difference(db_models))))
             self.txtStdout.clear()
             self.txtStdout.setTextColor(QColor('#000000'))
             self.txtStdout.setText(QCoreApplication.translate("DialogImportData", message_error))
@@ -259,15 +261,15 @@ class DialogImportData(QDialog, DIALOG_UI):
 
             # button is removed to define order in GUI
             for button in self.buttonBox.buttons():
-                if button.text() == QCoreApplication.translate("DialogImportData",  "Import data"):
+                if button.text() == self.BUTTON_NAME_IMPORT_DATA:
                     self.buttonBox.removeButton(button)
 
             # Check if button was previously added
             self.remove_create_structure_button()
 
-            self.buttonBox.addButton(QCoreApplication.translate("DialogImportData",  "Go to create structure..."),
+            self.buttonBox.addButton(self.BUTTON_NAME_GO_TO_CREATE_STRUCTURE,
                                      QDialogButtonBox.AcceptRole).setStyleSheet("color: #aa2222;")
-            self.buttonBox.addButton(QCoreApplication.translate("DialogImportData",  "Import data"),
+            self.buttonBox.addButton(self.BUTTON_NAME_IMPORT_DATA,
                                      QDialogButtonBox.AcceptRole)
 
             return
@@ -329,7 +331,7 @@ class DialogImportData(QDialog, DIALOG_UI):
 
     def remove_create_structure_button(self):
         for button in self.buttonBox.buttons():
-            if button.text() == QCoreApplication.translate("DialogImportData",  "Go to create structure..."):
+            if button.text() == self.BUTTON_NAME_GO_TO_CREATE_STRUCTURE:
                 self.buttonBox.removeButton(button)
 
     def save_configuration(self, configuration):

--- a/asistente_ladm_col/gui/qgis_model_baker/dlg_import_schema.py
+++ b/asistente_ladm_col/gui/qgis_model_baker/dlg_import_schema.py
@@ -24,8 +24,8 @@ from QgisModelBaker.libili2db.ili2dbconfig import (SchemaImportConfiguration,
 from QgisModelBaker.libili2db.ili2dbutils import color_log_text
 from QgisModelBaker.libili2db.ilicache import IliCache
 from QgisModelBaker.libili2db.iliimporter import JavaNotFoundError
+
 from qgis.PyQt.QtCore import (Qt,
-                              pyqtSignal,
                               QCoreApplication,
                               QSettings,
                               pyqtSignal)
@@ -61,8 +61,11 @@ DIALOG_UI = get_ui_class('qgis_model_baker/dlg_import_schema.ui')
 
 class DialogImportSchema(QDialog, DIALOG_UI):
 
-    models_have_changed = pyqtSignal(DBConnector, bool) # dbconn, ladm_col_db
+    models_have_changed = pyqtSignal(DBConnector, bool)  # dbconn, ladm_col_db
     open_dlg_import_data = pyqtSignal()
+
+    BUTTON_NAME_CREATE_STRUCTURE = QCoreApplication.translate("DialogImportSchema", "Create LADM-COL structure")
+    BUTTON_NAME_GO_TO_IMPORT_DATA =  QCoreApplication.translate("DialogImportData", "Go to Import Data...")
 
     def __init__(self, iface, qgis_utils, conn_manager, selected_models=list()):
         QDialog.__init__(self)
@@ -98,7 +101,7 @@ class DialogImportSchema(QDialog, DIALOG_UI):
         self.buttonBox.clicked.connect(self.accepted_import_schema)
         self.buttonBox.clear()
         self.buttonBox.addButton(QDialogButtonBox.Cancel)
-        self._accept_button = self.buttonBox.addButton(QCoreApplication.translate("DialogImportSchema", "Create LADM-COL structure"), QDialogButtonBox.AcceptRole)
+        self._accept_button = self.buttonBox.addButton(self.BUTTON_NAME_CREATE_STRUCTURE, QDialogButtonBox.AcceptRole)
         self.buttonBox.addButton(QDialogButtonBox.Help)
         self.buttonBox.helpRequested.connect(self.show_help)
 
@@ -107,9 +110,9 @@ class DialogImportSchema(QDialog, DIALOG_UI):
 
     def accepted_import_schema(self, button):
         if self.buttonBox.buttonRole(button) == QDialogButtonBox.AcceptRole:
-            if button.text() == QCoreApplication.translate("DialogImportData",  "Create LADM-COL structure"):
+            if button.text() == self.BUTTON_NAME_CREATE_STRUCTURE:
                 self.accepted()
-            elif button.text() == QCoreApplication.translate("DialogImportData",  "Go to import data..."):
+            elif button.text() == self.BUTTON_NAME_GO_TO_IMPORT_DATA:
                 self.close()  # Close import schema dialog and open import open dialog
                 self.open_dlg_import_data.emit()
 
@@ -125,17 +128,12 @@ class DialogImportSchema(QDialog, DIALOG_UI):
             self._accept_button.setEnabled(False)
 
     def update_import_models(self):
-        for modelname in DEFAULT_MODEL_NAMES_CHECKED:
+        for modelname, checked in DEFAULT_MODEL_NAMES_CHECKED.items():
             item = QListWidgetItem(modelname)
             item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
-
-            # Check selected models, always Catastro_Registro_Nucleo_V2_2_1 will be selected
-            if modelname in self.selected_models:
-                item.setCheckState(Qt.Checked)
-            else:
-                item.setCheckState(DEFAULT_MODEL_NAMES_CHECKED[modelname])
-
+            item.setCheckState(Qt.Checked if modelname in self.selected_models or checked == Qt.Checked else Qt.Unchecked)  # From parameter or by default
             self.import_models_list_widget.addItem(item)
+
         self.import_models_list_widget.itemClicked.connect(self.on_item_clicked_import_model)
         self.import_models_list_widget.itemChanged.connect(self.on_itemchanged_import_model)
 
@@ -235,8 +233,8 @@ class DialogImportSchema(QDialog, DIALOG_UI):
 
             self.buttonBox.clear()
 
-            self.buttonBox.addButton(QCoreApplication.translate("DialogImportData", "Go to import data..."),
-                                     QDialogButtonBox.AcceptRole).setStyleSheet("color: #aa2222;")
+            self.buttonBox.addButton(self.BUTTON_NAME_GO_TO_IMPORT_DATA,
+                                     QDialogButtonBox.AcceptRole).setStyleSheet("color: #007208;")
 
             self.buttonBox.setEnabled(True)
             self.buttonBox.addButton(QDialogButtonBox.Close)

--- a/asistente_ladm_col/utils/decorators.py
+++ b/asistente_ladm_col/utils/decorators.py
@@ -63,7 +63,7 @@ def _qgis_model_baker_required(func_to_decorate):
                                                             QGIS_MODEL_BAKER_EXACT_REQUIRED_VERSION)
 
         if plugin_version_right:
-            func_to_decorate(inst)
+            func_to_decorate(inst, *args, **kwargs)
         else:
             if QGIS_MODEL_BAKER_REQUIRED_VERSION_URL:
                 # If we depend on a specific version of QGIS Model Baker (only on that one)


### PR DESCRIPTION
- [x] In DialogImportSchema after creating a schema structure there is a new button that allows you to go to DialogImportData.
- [x] When in DialogImportData the scheme does not have the same models as the ili file, a new button is available to go to DialogImportSchema with the necessary models selected.