### PR TITLE
Zoom to official plot in change detection 

### DIFF
--- a/asistente_ladm_col/gui/change_detection/dockwidget_change_detection.py
+++ b/asistente_ladm_col/gui/change_detection/dockwidget_change_detection.py
@@ -260,8 +260,13 @@ class ChangeDetectionUtils(QObject):
                                        load=True,
                                        emit_map_freeze=False,
                                        layer_modifiers=layer_modifiers)
+
             if not self._official_layers:
                 return None
+            else:
+                # In some occasions the official and collected plots do not overlap and there are in different extents
+                self.iface.setActiveLayer(self._official_layers[PLOT_TABLE][LAYER])
+                self.iface.zoomToActiveLayer()
 
             self.qgis_utils.map_freeze_requested.emit(False)
 


### PR DESCRIPTION
- [x] Zoom to official plot: In some occasions the official and collected plots do not overlap and there are in different extents