### PR TITLE
[processing] Optimize Insert Features to Layer 

### DIFF
--- a/asistente_ladm_col/asistente_ladm_col_plugin.py
+++ b/asistente_ladm_col/asistente_ladm_col_plugin.py
@@ -1073,10 +1073,11 @@ class AsistenteLADMCOLPlugin(QObject):
     def show_dlg_group_party(self, *args):
         namespace_enabled = QSettings().value('Asistente-LADM_COL/automatic_values/namespace_enabled', True, bool)
         local_id_enabled = QSettings().value('Asistente-LADM_COL/automatic_values/local_id_enabled', True, bool)
+        t_ili_tid_enabled = QSettings().value('Asistente-LADM_COL/automatic_values/t_ili_tid_enabled', True, bool)
 
-        if not namespace_enabled or not local_id_enabled:
+        if not namespace_enabled or not local_id_enabled or not t_ili_tid_enabled:
             self.show_message_with_settings_button(QCoreApplication.translate("CreateGroupPartyOperation",
-                                                       "First enable automatic values for both namespace and local_id fields before creating group parties. Click the button to open the settings dialog."),
+                                                       "First enable automatic values for namespace, local_id and t_ili_tid fields before creating group parties. Click the button to open the settings dialog."),
                                                    QCoreApplication.translate("CreateGroupPartyOperation", "Open Settings"),
                                                    Qgis.Info)
             return

--- a/asistente_ladm_col/config/layer_config.py
+++ b/asistente_ladm_col/config/layer_config.py
@@ -404,8 +404,8 @@ class LayerConfig:
     @staticmethod
     def get_dict_automatic_values(names):
         return {
-            names.OP_BOUNDARY_T: [{names.OP_BOUNDARY_T_LENGTH_F: "$length"}],
-            names.OP_PARTY_T: [{
+            names.OP_BOUNDARY_T: {names.OP_BOUNDARY_T_LENGTH_F: "$length"},
+            names.OP_PARTY_T: {
                 names.COL_PARTY_T_NAME_F: """
                     CASE
                         WHEN {party_type} = get_domain_code_from_value('{domain_party_type}', '{OP_PARTY_TYPE_D_ILICODE_F_NATURAL_PARTY_V}', True, False)  THEN
@@ -422,10 +422,11 @@ class LayerConfig:
                            business_name=names.OP_PARTY_T_BUSINESS_NAME_F,
                            OP_PARTY_TYPE_D_ILICODE_F_NOT_NATURAL_PARTY_V=LADMNames.OP_PARTY_TYPE_D_ILICODE_F_NOT_NATURAL_PARTY_V,
                            OP_PARTY_TYPE_D_ILICODE_F_NATURAL_PARTY_V=LADMNames.OP_PARTY_TYPE_D_ILICODE_F_NATURAL_PARTY_V)
-            }],
-            names.OP_PARCEL_T: [
-                {names.OP_PARCEL_T_DEPARTMENT_F: 'substr("{}", 0, 2)'.format(names.OP_PARCEL_T_PARCEL_NUMBER_F)},
-                {names.OP_PARCEL_T_MUNICIPALITY_F: 'substr("{}", 3, 3)'.format(names.OP_PARCEL_T_PARCEL_NUMBER_F)}]
+            },
+            names.OP_PARCEL_T: {
+                names.OP_PARCEL_T_DEPARTMENT_F: 'substr("{}", 0, 2)'.format(names.OP_PARCEL_T_PARCEL_NUMBER_F),
+                names.OP_PARCEL_T_MUNICIPALITY_F: 'substr("{}", 3, 3)'.format(names.OP_PARCEL_T_PARCEL_NUMBER_F)
+            }
         }
 
     @staticmethod

--- a/asistente_ladm_col/config/layer_config.py
+++ b/asistente_ladm_col/config/layer_config.py
@@ -13,7 +13,7 @@ class LayerConfig:
 
     @staticmethod
     def get_layer_constraints(names):
-        return  {
+        return {
             names.OP_PARCEL_T: {
                 names.OP_PARCEL_T_PARCEL_TYPE_F: {
                     'expression': """

--- a/asistente_ladm_col/config/mapping_config.py
+++ b/asistente_ladm_col/config/mapping_config.py
@@ -3,6 +3,7 @@ from asistente_ladm_col.lib.logger import Logger
 
 
 T_ID_KEY = 't_id'
+T_ILI_TID_KEY = "t_ili_tid",
 DESCRIPTION_KEY = 'description'
 ILICODE_KEY = 'ilicode'
 DISPLAY_NAME_KEY = 'display_name'
@@ -18,6 +19,7 @@ class TableAndFieldNames:
 
     ############################################ TABLE VARIABLES ###########################################################
     T_ID_F = None
+    T_ILI_TID_F = None
     ILICODE_F = None
     DESCRIPTION_F = None
     DISPLAY_NAME_F = None
@@ -1179,7 +1181,11 @@ class TableAndFieldNames:
         table_names_count = 0
         field_names_count = 0
         if dict_names:
-            if T_ID_KEY not in dict_names or DISPLAY_NAME_KEY not in dict_names or ILICODE_KEY not in dict_names or DESCRIPTION_KEY not in dict_names:
+            if T_ID_KEY not in dict_names \
+                    or T_ILI_TID_KEY not in dict_names \
+                    or DISPLAY_NAME_KEY not in dict_names \
+                    or ILICODE_KEY not in dict_names \
+                    or DESCRIPTION_KEY not in dict_names:
                 self.logger.error(__name__, "dict_names is not properly built, at least one of these required fields was not found T_ID, DISPLAY_NAME, ILICODE and DESCRIPTION.")
                 return False
 
@@ -1195,6 +1201,7 @@ class TableAndFieldNames:
 
             # Required fields mapped in a custom way
             self.T_ID_F = dict_names[T_ID_KEY] if T_ID_KEY in dict_names else None
+            self.T_ILI_TID_F = dict_names[T_ILI_TID_KEY] if T_ILI_TID_KEY in dict_names else None
             self.ILICODE_F = dict_names[ILICODE_KEY] if ILICODE_KEY in dict_names else None
             self.DESCRIPTION_F = dict_names[DESCRIPTION_KEY] if DESCRIPTION_KEY in dict_names else None
             self.DISPLAY_NAME_F = dict_names[DISPLAY_NAME_KEY] if DISPLAY_NAME_KEY in dict_names else None
@@ -1214,6 +1221,7 @@ class TableAndFieldNames:
                 setattr(self, field_variable, None)
 
         self.T_ID_F = None
+        self.T_ILI_TID_F = None
         self.ILICODE_F = None
         self.DESCRIPTION_F = None
         self.DISPLAY_NAME_F = None

--- a/asistente_ladm_col/config/refactor_fields_mappings.py
+++ b/asistente_ladm_col/config/refactor_fields_mappings.py
@@ -405,7 +405,7 @@ class RefactorFieldsMappings:
     def set_automatic_values(self, names, mapping, layer_name):
         # Now see if we can adjust the mapping depending on user settings
         ns_enabled, ns_field, ns_value = self.app.core.get_namespace_field_and_value(names, layer_name)
-        lid_enabled, lid_field, lid_value = self.app.core.get_local_id_field_and_value(names, layer_name)
+        lid_enabled, lid_field, lid_value = self.app.core.get_local_id_field_and_value(names)
 
         for field in mapping:
             if ns_enabled and ns_field:

--- a/asistente_ladm_col/core/app_core_interface.py
+++ b/asistente_ladm_col/core/app_core_interface.py
@@ -602,7 +602,7 @@ class AppCoreInterface(QObject):
             list_dicts_field_expression.append({db.names.VERSIONED_OBJECT_T_BEGIN_LIFESPAN_VERSION_F: "now()"})
 
         if layer.fields().indexFromName(db.names.T_ILI_TID_F) != -1:
-            list_dicts_field_expression.append({db.names.T_ILI_TID_F: "uuid()"})
+            list_dicts_field_expression.append({db.names.T_ILI_TID_F: "substr(uuid(), 2, 36)"})
 
         dict_automatic_values = LayerConfig.get_dict_automatic_values(db.names)
         if layer_name in dict_automatic_values:

--- a/asistente_ladm_col/core/app_core_interface.py
+++ b/asistente_ladm_col/core/app_core_interface.py
@@ -596,12 +596,19 @@ class AppCoreInterface(QObject):
     def set_automatic_fields(self, db, layer, layer_name):
         self.set_automatic_fields_namespace_local_id(db, layer_name, layer)
 
+        list_dicts_field_expression = list()
+
         if layer.fields().indexFromName(db.names.VERSIONED_OBJECT_T_BEGIN_LIFESPAN_VERSION_F) != -1:
-            self.configure_automatic_fields(db, layer, [{db.names.VERSIONED_OBJECT_T_BEGIN_LIFESPAN_VERSION_F: "now()"}])
+            list_dicts_field_expression.append({db.names.VERSIONED_OBJECT_T_BEGIN_LIFESPAN_VERSION_F: "now()"})
+
+        if layer.fields().indexFromName(db.names.T_ILI_TID_F) != -1:
+            list_dicts_field_expression.append({db.names.T_ILI_TID_F: "uuid()"})
 
         dict_automatic_values = LayerConfig.get_dict_automatic_values(db.names)
         if layer_name in dict_automatic_values:
-            self.configure_automatic_fields(db, layer, dict_automatic_values[layer_name])
+            list_dicts_field_expression.extend(dict_automatic_values[layer_name])
+
+        self.configure_automatic_fields(db, layer, list_dicts_field_expression)
 
     def set_automatic_fields_namespace_local_id(self, db, layer_name, layer):
         ns_enabled, ns_field, ns_value = self.get_namespace_field_and_value(db.names, layer_name)

--- a/asistente_ladm_col/gui/dialogs/dlg_import_from_excel.py
+++ b/asistente_ladm_col/gui/dialogs/dlg_import_from_excel.py
@@ -249,9 +249,9 @@ class ImportFromExcelDialog(QDialog, DIALOG_UI):
                   'opfuenteadministrativatipo': layers[self.names.OP_ADMINISTRATIVE_SOURCE_T],
                   'parcel': layers[self.names.OP_PARCEL_T]}
 
-        self.app.core.disable_automatic_fields(self._db, self.names.OP_GROUP_PARTY_T)
-        self.app.core.disable_automatic_fields(self._db, self.names.OP_RIGHT_T)
-        self.app.core.disable_automatic_fields(self._db, self.names.OP_ADMINISTRATIVE_SOURCE_T)
+        self.app.core.disable_automatic_fields(layers[self.names.OP_GROUP_PARTY_T])
+        self.app.core.disable_automatic_fields(layers[self.names.OP_RIGHT_T])
+        self.app.core.disable_automatic_fields(layers[self.names.OP_ADMINISTRATIVE_SOURCE_T])
 
         processing.run("model:ETL_intermediate_structure", params, feedback=self.feedback)
 

--- a/asistente_ladm_col/gui/dialogs/dlg_settings.py
+++ b/asistente_ladm_col/gui/dialogs/dlg_settings.py
@@ -298,7 +298,6 @@ class SettingsDialog(QDialog, DIALOG_UI):
 
         settings.setValue('Asistente-LADM_COL/quality/use_roads', self.chk_use_roads.isChecked())
 
-        settings.setValue('Asistente-LADM_COL/automatic_values/automatic_values_in_batch_mode', self.chk_automatic_values_in_batch_mode.isChecked())
         settings.setValue('Asistente-LADM_COL/sources/document_repository', self.connection_box.isChecked())
 
         settings.setValue('Asistente-LADM_COL/models/validate_data_importing_exporting', self.chk_validate_data_importing_exporting.isChecked())
@@ -309,22 +308,27 @@ class SettingsDialog(QDialog, DIALOG_UI):
         endpoint = self.txt_service_endpoint.text().strip()
         settings.setValue('Asistente-LADM_COL/sources/service_endpoint', (endpoint[:-1] if endpoint.endswith('/') else endpoint) or DEFAULT_ENDPOINT_SOURCE_SERVICE)
 
-        # Changes in automatic namespace or local_id configuration?
+        settings.setValue('Asistente-LADM_COL/automatic_values/automatic_values_in_batch_mode', self.chk_automatic_values_in_batch_mode.isChecked())
+
+        # Changes in automatic namespace, local_id or t_ili_tid configuration?
         current_namespace_enabled = settings.value('Asistente-LADM_COL/automatic_values/namespace_enabled', True, bool)
         current_namespace_prefix = settings.value('Asistente-LADM_COL/automatic_values/namespace_prefix', "")
         current_local_id_enabled = settings.value('Asistente-LADM_COL/automatic_values/local_id_enabled', True, bool)
+        current_t_ili_tid_enabled = settings.value('Asistente-LADM_COL/automatic_values/t_ili_tid_enabled', True, bool)
 
         settings.setValue('Asistente-LADM_COL/automatic_values/namespace_enabled', self.namespace_collapsible_group_box.isChecked())
         if self.namespace_collapsible_group_box.isChecked():
             settings.setValue('Asistente-LADM_COL/automatic_values/namespace_prefix', self.txt_namespace.text())
 
         settings.setValue('Asistente-LADM_COL/automatic_values/local_id_enabled', self.chk_local_id.isChecked())
+        settings.setValue('Asistente-LADM_COL/automatic_values/t_ili_tid_enabled', self.chk_t_ili_tid.isChecked())
 
         if current_namespace_enabled != self.namespace_collapsible_group_box.isChecked() or \
            current_namespace_prefix != self.txt_namespace.text() or \
-           current_local_id_enabled != self.chk_local_id.isChecked():
+           current_local_id_enabled != self.chk_local_id.isChecked() or \
+           current_t_ili_tid_enabled != self.chk_t_ili_tid.isChecked():
             if self._db is not None:
-                self.app.core.automatic_namespace_local_id_configuration_changed(self._db)
+                self.app.core.automatic_fields_settings_changed(self._db)
 
     def restore_db_source_settings(self):
         settings = QSettings()
@@ -369,6 +373,7 @@ class SettingsDialog(QDialog, DIALOG_UI):
         self.connection_box.setChecked(settings.value('Asistente-LADM_COL/sources/document_repository', True, bool))
         self.namespace_collapsible_group_box.setChecked(settings.value('Asistente-LADM_COL/automatic_values/namespace_enabled', True, bool))
         self.chk_local_id.setChecked(settings.value('Asistente-LADM_COL/automatic_values/local_id_enabled', True, bool))
+        self.chk_t_ili_tid.setChecked(settings.value('Asistente-LADM_COL/automatic_values/t_ili_tid_enabled', True, bool))
         self.txt_namespace.setText(str(settings.value('Asistente-LADM_COL/automatic_values/namespace_prefix', "")))
 
         self.chk_validate_data_importing_exporting.setChecked(settings.value('Asistente-LADM_COL/models/validate_data_importing_exporting', True, bool))

--- a/asistente_ladm_col/gui/toolbar.py
+++ b/asistente_ladm_col/gui/toolbar.py
@@ -81,7 +81,7 @@ class ToolBar(QObject):
             for boundary_geom in new_boundary_geoms:
                 feature = QgsVectorLayerUtils().createFeature(layer, boundary_geom)
 
-                # TODO: Remove when local id and working space are defined
+                # TODO: Remove when local id and namespace are defined
                 feature.setAttribute(db.names.OID_T_LOCAL_ID_F, 1)
                 feature.setAttribute(db.names.OID_T_NAMESPACE_F, db.names.OP_BOUNDARY_T)
 

--- a/asistente_ladm_col/gui/wizards/operation/dlg_create_group_party_operation.py
+++ b/asistente_ladm_col/gui/wizards/operation/dlg_create_group_party_operation.py
@@ -352,11 +352,11 @@ class CreateGroupPartyOperation(QDialog, DIALOG_UI):
             new_feature.setAttribute(self.names.COL_GROUP_PARTY_T_TYPE_F, group[self.names.COL_GROUP_PARTY_T_TYPE_F])
             new_feature.setAttribute(self.names.COL_PARTY_T_NAME_F, group[self.names.COL_PARTY_T_NAME_F])
 
-            # TODO: Remove when local id and working space are defined
-            new_feature.setAttribute(self.names.OID_T_LOCAL_ID_F, 1)
-            new_feature.setAttribute(self.names.OID_T_NAMESPACE_F, self.names.OP_GROUP_PARTY_T)
+            # TODO: Remove when local id and namespace are defined
+            #new_feature.setAttribute(self.names.OID_T_LOCAL_ID_F, 1)
+            #new_feature.setAttribute(self.names.OID_T_NAMESPACE_F, self.names.OP_GROUP_PARTY_T)
 
-            # TODO: Gui should allow users to ented namespace, local_id and date values
+            # TODO: Gui should allow users to enter namespace, local_id and date values
             #new_feature.setAttribute("p_espacio_de_nombres", self.names.OP_GROUP_PARTY_T)
             #new_feature.setAttribute("p_local_id", '0')
             #new_feature.setAttribute("comienzo_vida_util_version", 'now()')

--- a/asistente_ladm_col/i18n/Asistente-LADM_COL_es.ts
+++ b/asistente_ladm_col/i18n/Asistente-LADM_COL_es.ts
@@ -1616,8 +1616,8 @@
     </message>
     <message>
         <location filename="../asistente_ladm_col_plugin.py" line="1122"/>
-        <source>First enable automatic values for both namespace and local_id fields before creating group parties. Click the button to open the settings dialog.</source>
-        <translation>Primero habilita los valores automáticos para los campos &apos;espacio de nombres&apos; y &apos;local_id&apos; antes de crear agrupaciones de interesados. Haz clic en el botón para abrir el diálogo de configuración.</translation>
+        <source>First enable automatic values for namespace, local_id and t_ili_tid fields before creating group parties. Click the button to open the settings dialog.</source>
+        <translation>Primero habilita los valores automáticos para los campos &apos;espacio de nombres&apos;, &apos;local_id&apos; y &apos;t_ili_tid&apos; antes de crear agrupaciones de interesados. Haz clic en el botón para abrir el diálogo de configuración.</translation>
     </message>
     <message>
         <location filename="../asistente_ladm_col_plugin.py" line="1124"/>

--- a/asistente_ladm_col/lib/db/db_connector.py
+++ b/asistente_ladm_col/lib/db/db_connector.py
@@ -27,6 +27,7 @@ from asistente_ladm_col.config.enums import (EnumTestLevel,
                                              EnumTestConnectionMsg)
 from asistente_ladm_col.config.mapping_config import (TableAndFieldNames,
                                                       T_ID_KEY,
+                                                      T_ILI_TID_KEY,
                                                       DISPLAY_NAME_KEY,
                                                       ILICODE_KEY,
                                                       DESCRIPTION_KEY)
@@ -247,7 +248,7 @@ class DBConnector(QObject):
         """
         # Fill table names
         for k,v in dict_names.items():
-            if k not in [T_ID_KEY, DISPLAY_NAME_KEY, ILICODE_KEY, DESCRIPTION_KEY]:  # Custom names will be handled by Names class
+            if k not in [T_ID_KEY, T_ILI_TID_KEY, DISPLAY_NAME_KEY, ILICODE_KEY, DESCRIPTION_KEY]:  # Custom names will be handled by Names class
                 self._table_and_field_names.append(k)  # Table names
                 for k1, v1 in v.items():
                     if k1 != QueryNames.TABLE_NAME:

--- a/asistente_ladm_col/lib/db/gpkg_connector.py
+++ b/asistente_ladm_col/lib/db/gpkg_connector.py
@@ -26,6 +26,7 @@ from asistente_ladm_col.config.enums import (EnumTestLevel,
                                              EnumUserLevel,
                                              EnumTestConnectionMsg)
 from asistente_ladm_col.config.mapping_config import (T_ID_KEY,
+                                                      T_ILI_TID_KEY,
                                                       DISPLAY_NAME_KEY,
                                                       ILICODE_KEY,
                                                       DESCRIPTION_KEY)
@@ -234,6 +235,7 @@ class GPKGConnector(DBConnector):
 
         # Custom names
         dict_names[T_ID_KEY] = "T_Id"
+        dict_names[T_ILI_TID_KEY] = "T_Ili_Tid"
         dict_names[DISPLAY_NAME_KEY] = "dispName"
         dict_names[ILICODE_KEY] = "iliCode"
         dict_names[DESCRIPTION_KEY] = "description"

--- a/asistente_ladm_col/lib/db/pg_connector.py
+++ b/asistente_ladm_col/lib/db/pg_connector.py
@@ -39,6 +39,7 @@ from asistente_ladm_col.config.ladm_names import LADMNames
 from asistente_ladm_col.core.model_parser import ModelParser
 from asistente_ladm_col.utils.utils import normalize_iliname
 from asistente_ladm_col.config.mapping_config import (T_ID_KEY,
+                                                      T_ILI_TID_KEY,
                                                       DISPLAY_NAME_KEY,
                                                       ILICODE_KEY,
                                                       DESCRIPTION_KEY)
@@ -340,6 +341,7 @@ class PGConnector(DBConnector):
 
         # Add required key-value pairs that do not come from the DB query
         dict_names[T_ID_KEY] = "t_id"
+        dict_names[T_ILI_TID_KEY] = "t_ili_tid"
         dict_names[DISPLAY_NAME_KEY] = "dispname"
         dict_names[ILICODE_KEY] = "ilicode"
         dict_names[DESCRIPTION_KEY] = "description"

--- a/asistente_ladm_col/lib/processing/algs/InsertFeaturesToLayer.py
+++ b/asistente_ladm_col/lib/processing/algs/InsertFeaturesToLayer.py
@@ -24,12 +24,16 @@ from qgis.core import (edit,
                        QgsGeometry,
                        QgsWkbTypes,
                        QgsProcessing,
+                       QgsProcessingFeedback,
                        QgsProcessingAlgorithm,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingOutputVectorLayer,
                        QgsProject,
-                       QgsVectorLayerUtils)
+                       QgsVectorLayerUtils,
+                       QgsVectorLayer,
+                       QgsFeatureSink)
+
 
 class InsertFeaturesToLayer(QgsProcessingAlgorithm):
 
@@ -70,111 +74,61 @@ class InsertFeaturesToLayer(QgsProcessingAlgorithm):
     def processAlgorithm(self, parameters, context, feedback):
         source = self.parameterAsSource(parameters, self.INPUT, context)
         target = self.parameterAsVectorLayer(parameters, self.OUTPUT, context)
-        target.dataProvider().clearErrors()
+        target_provider = target.dataProvider()
+        target_provider.clearErrors()
 
-        editable_before = False
         if target.isEditable():
-            editable_before = True
             feedback.reportError("\nWARNING: You need to close the edit session on layer '{}' before running this algorithm.".format(
                 target.name()
             ))
             return {self.OUTPUT: None}
 
-        # Define a mapping between source and target layer
-        mapping = dict()
-        for target_idx in target.fields().allAttributesList():
-            target_field = target.fields().field(target_idx)
-            source_idx = source.fields().indexOf(target_field.name())
-            if source_idx != -1:
-                mapping[target_idx] = source_idx
-
         # Copy and Paste
-        total = 100.0 / source.featureCount() if source.featureCount() else 0
-        features = source.getFeatures()
-        destType = target.geometryType()
-        destIsMulti = QgsWkbTypes.isMultiType(target.wkbType())
+        #total = 100.0 / source.featureCount() if source.featureCount() else 0
+        #count = 0
+        #feedback.setProgress(int(current * total))
 
-        #  Check if layer has Z or M values.
-        drop_coordinates = list()
-        add_coordinates = list()
-        if QgsWkbTypes().hasM(source.wkbType()):
-            # In ladm we don't use M values, so drop them if present
-            drop_coordinates.append("M")
-        if not QgsWkbTypes().hasZ(source.wkbType()) and QgsWkbTypes().hasZ(target.wkbType()):
-            add_coordinates.append("Z")
-        if QgsWkbTypes().hasZ(source.wkbType()) and not QgsWkbTypes().hasZ(target.wkbType()):
-            drop_coordinates.append("Z")
+        features = QgsVectorLayerUtils().makeFeaturesCompatible(source.getFeatures(), target)
+        for feature in features:
+            for idx in target_provider.pkAttributeIndexes():
+                feature.setAttribute(idx, target_provider.defaultValue(idx))
 
-        new_features = []
-        display_target_geometry = QgsWkbTypes.displayString(target.wkbType())
-        display_source_geometry = QgsWkbTypes.displayString(source.wkbType())
-
-        for current, in_feature in enumerate(features):
-            if feedback.isCanceled():
-                break
-
-            attrs = {target_idx: in_feature[source_idx] for target_idx, source_idx in mapping.items()}
-
-            geom = QgsGeometry()
-
-            if in_feature.hasGeometry() and target.isSpatial():
-                # Convert geometry to match destination layer
-                # Adapted from QGIS qgisapp.cpp, pasteFromClipboard()
-                geom = in_feature.geometry()
-
-                if destType != QgsWkbTypes.UnknownGeometry:
-                    newGeometry = geom.convertToType(destType, destIsMulti)
-                    if newGeometry.isNull():
-                        feedback.reportError("\nERROR: Geometry type from the source layer ('{}') could not be converted to '{}'.".format(
-                            display_source_geometry,
-                            display_target_geometry
-                        ))
-                        return {self.OUTPUT: None}
-                    newGeometry = self.transform_geom(newGeometry, drop_coordinates, add_coordinates)
-                    geom = newGeometry
-
-                # Avoid intersection if enabled in digitize settings
-                geom.avoidIntersections(QgsProject.instance().avoidIntersectionsLayers())
-
-            new_feature = QgsVectorLayerUtils().createFeature(target, geom, attrs)
-            new_features.append(new_feature)
-
-            feedback.setProgress(int(current * total))
-
-        try:
-            # This might print error messages... But, hey! That's what we want!
-            res = target.dataProvider().addFeatures(new_features)
-        except QgsEditError as e:
-            if not editable_before:
-                # Let's close the edit session to prepare for a next run
-                target.rollBack()
-
-            feedback.reportError("\nERROR: No features could be copied into '{}', because of the following error:\n{}\n".format(
-                target.name(),
-                repr(e)
-            ))
-            return {self.OUTPUT: None}
-
-        if res[0]:
+        if self.save_features(target, features, 'provider', feedback):
             feedback.pushInfo("\nSUCCESS: {} out of {} features from input layer were successfully copied into '{}'!".format(
-                    len(new_features),
+                    len(features),
                     source.featureCount(),
                     target.name()
-            ))         
-        else:
-            if target.dataProvider().hasErrors():
-                feedback.reportError("\nERROR: The data could not be copied! Details: {}.".format(target.dataProvider().errors()[0]))
-            else:
-                feedback.reportError("\nERROR: The data could not be copied! No more details from the provider.")
+            ))
+        else:  # Messages are handled by save_features method
+            return {self.OUTPUT: None}
             
         return {self.OUTPUT: target}
 
-    def transform_geom(self, geom, drop_coordinates, add_coordinates):
-        """Add/remove Z and remove M values"""
-        if "Z" in drop_coordinates:
-            geom.get().dropZValue()
-        if "M" in drop_coordinates:
-            geom.get().dropMValue()
-        if "Z" in add_coordinates:
-            geom.get().addZValue()
-        return geom
+    def save_features(self, layer, features, mode='provider', feedback=QgsProcessingFeedback()):
+        res = False
+        if mode == 'provider':
+            feedback.pushInfo("Saving features using data provider...")
+            layer.dataProvider().clearErrors()
+            res = layer.dataProvider().addFeatures(features, QgsFeatureSink.FastInsert)[0]
+            if not res:
+                if layer.dataProvider().hasErrors():
+                    feedback.reportError(
+                        "\nERROR: The data could not be copied! Details: {}.".format(layer.dataProvider().errors()))
+                else:
+                    feedback.reportError("\nERROR: The data could not be copied! No more details from the provider.")
+        elif mode == 'edit_session':
+            feedback.pushInfo("Saving features using edit session...")
+            try:
+                with edit(layer):
+                    res = layer.addFeatures(features, QgsFeatureSink.FastInsert)
+            except QgsEditError as e:
+                # Let's close the edit session to prepare for a next run
+                layer.rollBack()
+                feedback.reportError(
+                    "\nERROR: No features could be copied into '{}', because of the following error:\n{}\n".format(
+                        layer.name(),
+                        repr(e)
+                    ))
+                res = False
+
+        return res

--- a/asistente_ladm_col/tests/test_all_models.py
+++ b/asistente_ladm_col/tests/test_all_models.py
@@ -56,7 +56,7 @@ class TestAllModels(unittest.TestCase):
         self.assertTrue(res, msg)
 
         dict_names = self.db_pg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 215)
+        self.assertEqual(len(dict_names), 216)
 
         expected_dict = {T_ID_KEY: 't_id',
                          T_ILI_TID_KEY: "t_ili_tid",

--- a/asistente_ladm_col/tests/test_all_models.py
+++ b/asistente_ladm_col/tests/test_all_models.py
@@ -11,6 +11,7 @@ from asistente_ladm_col.tests.utils import (get_required_fields,
                                             unload_qgis_model_baker)
 from asistente_ladm_col.config.mapping_config import (ILICODE_KEY,
                                                       T_ID_KEY,
+                                                      T_ILI_TID_KEY,
                                                       DESCRIPTION_KEY,
                                                       DISPLAY_NAME_KEY)
 from asistente_ladm_col.tests.utils import (get_pg_conn,
@@ -58,6 +59,7 @@ class TestAllModels(unittest.TestCase):
         self.assertEqual(len(dict_names), 215)
 
         expected_dict = {T_ID_KEY: 't_id',
+                         T_ILI_TID_KEY: "t_ili_tid",
                          ILICODE_KEY: 'ilicode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispname',
@@ -92,9 +94,10 @@ class TestAllModels(unittest.TestCase):
         self.assertTrue(res, msg)
 
         dict_names = self.db_gpkg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 215)
+        self.assertEqual(len(dict_names), 216)
 
         expected_dict = {T_ID_KEY: 'T_Id',
+                         T_ILI_TID_KEY: "T_Ili_Tid",
                          ILICODE_KEY: 'iliCode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispName',

--- a/asistente_ladm_col/tests/test_ant_model.py
+++ b/asistente_ladm_col/tests/test_ant_model.py
@@ -9,6 +9,7 @@ from asistente_ladm_col.tests.utils import (get_required_fields,
                                             get_required_tables)
 from asistente_ladm_col.config.mapping_config import (ILICODE_KEY,
                                                       T_ID_KEY,
+                                                      T_ILI_TID_KEY,
                                                       DESCRIPTION_KEY,
                                                       DISPLAY_NAME_KEY)
 from asistente_ladm_col.tests.utils import (get_pg_conn,
@@ -51,8 +52,9 @@ class TestANTModel(unittest.TestCase):
         result = self.db_pg.test_connection()
         self.assertTrue(result[0], 'The test connection is not working')
         dict_names = self.db_pg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 162)
+        self.assertEqual(len(dict_names), 163)
         expected_dict = {T_ID_KEY: 't_id',
+                         T_ILI_TID_KEY: "t_ili_tid",
                          ILICODE_KEY: 'ilicode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispname',
@@ -72,8 +74,9 @@ class TestANTModel(unittest.TestCase):
         result = self.db_gpkg.test_connection()
         self.assertTrue(result[0], 'The test connection is not working')
         dict_names = self.db_gpkg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 162)
+        self.assertEqual(len(dict_names), 163)
         expected_dict = {T_ID_KEY: 'T_Id',
+                         T_ILI_TID_KEY: "T_Ili_Tid",
                          ILICODE_KEY: 'iliCode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispName',

--- a/asistente_ladm_col/tests/test_cadastral_form_model.py
+++ b/asistente_ladm_col/tests/test_cadastral_form_model.py
@@ -9,6 +9,7 @@ from asistente_ladm_col.tests.utils import (get_required_fields,
                                             get_required_tables)
 from asistente_ladm_col.config.mapping_config import (ILICODE_KEY,
                                                       T_ID_KEY,
+                                                      T_ILI_TID_KEY,
                                                       DESCRIPTION_KEY,
                                                       DISPLAY_NAME_KEY)
 from asistente_ladm_col.tests.utils import (get_pg_conn,
@@ -52,8 +53,9 @@ class TestCadastralFormModel(unittest.TestCase):
         self.assertTrue(result[0], 'The test connection is not working')
 
         dict_names = self.db_pg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 177)
+        self.assertEqual(len(dict_names), 178)
         expected_dict = {T_ID_KEY: 't_id',
+                         T_ILI_TID_KEY: "t_ili_tid",
                          ILICODE_KEY: 'ilicode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispname',
@@ -71,8 +73,9 @@ class TestCadastralFormModel(unittest.TestCase):
         self.assertTrue(result[0], 'The test connection is not working')
 
         dict_names = self.db_gpkg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 177)
+        self.assertEqual(len(dict_names), 178)
         expected_dict = {T_ID_KEY: 'T_Id',
+                         T_ILI_TID_KEY: "T_Ili_Tid",
                          ILICODE_KEY: 'iliCode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispName',

--- a/asistente_ladm_col/tests/test_cadastral_manager_data_model.py
+++ b/asistente_ladm_col/tests/test_cadastral_manager_data_model.py
@@ -9,6 +9,7 @@ from asistente_ladm_col.tests.utils import (get_required_fields,
                                             get_required_tables)
 from asistente_ladm_col.config.mapping_config import (ILICODE_KEY,
                                                       T_ID_KEY,
+                                                      T_ILI_TID_KEY,
                                                       DESCRIPTION_KEY,
                                                       DISPLAY_NAME_KEY)
 from asistente_ladm_col.tests.utils import (get_pg_conn,
@@ -52,9 +53,10 @@ class TestCadastralManagerDataModel(unittest.TestCase):
         self.assertTrue(result[0], 'The test connection is not working')
 
         dict_names = self.db_pg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 28)
+        self.assertEqual(len(dict_names), 29)
 
         expected_dict = {T_ID_KEY: 't_id',
+                         T_ILI_TID_KEY: "t_ili_tid",
                          ILICODE_KEY: 'ilicode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispname',
@@ -86,9 +88,10 @@ class TestCadastralManagerDataModel(unittest.TestCase):
         self.assertTrue(result[0], 'The test connection is not working')
 
         dict_names = self.db_gpkg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 28)
+        self.assertEqual(len(dict_names), 29)
 
         expected_dict = {T_ID_KEY: 'T_Id',
+                         T_ILI_TID_KEY: "T_Ili_Tid",
                          ILICODE_KEY: 'iliCode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispName',

--- a/asistente_ladm_col/tests/test_copy_csv_points_to_db.py
+++ b/asistente_ladm_col/tests/test_copy_csv_points_to_db.py
@@ -54,7 +54,8 @@ class TestCopy(unittest.TestCase):
     def test_copy_csv_to_db(self):
         print("\nINFO: Validating copy CSV points to DB...")
         clean_table(SCHEMA_LADM_COL_EMPTY, self.names.OP_BOUNDARY_POINT_T)
-        self.app.core.disable_automatic_fields(self.db_pg, self.names.OP_BOUNDARY_POINT_T)
+        layer = self.app.core.get_layer(self.db_pg, self.names.OP_BOUNDARY_POINT_T, True)
+        self.app.core.disable_automatic_fields(layer)
 
         csv_path = get_test_path('csv/puntos_fixed_v296.csv')
         txt_delimiter = ';'
@@ -93,7 +94,8 @@ class TestCopy(unittest.TestCase):
 
     def test_upload_points_from_csv_crs_wgs84(self):
         print("\nINFO: Copying CSV data with EPSG:4326...")
-        self.app.core.disable_automatic_fields(self.db_pg, self.names.OP_BOUNDARY_POINT_T)
+        layer = self.app.core.get_layer(self.db_pg, self.names.OP_BOUNDARY_POINT_T, True)
+        self.app.core.disable_automatic_fields(layer)
 
         csv_path = get_test_path('csv/puntos_crs_4326_wgs84_v296.csv')
         txt_delimiter = ';'
@@ -130,7 +132,8 @@ class TestCopy(unittest.TestCase):
     def test_copy_csv_with_z_to_db(self):
         print("\nINFO: Validating copy CSV points with Z to DB...")
         clean_table(SCHEMA_LADM_COL_EMPTY, self.names.OP_BOUNDARY_POINT_T)
-        self.app.core.disable_automatic_fields(self.db_pg, self.names.OP_BOUNDARY_POINT_T)
+        layer = self.app.core.get_layer(self.db_pg, self.names.OP_BOUNDARY_POINT_T, True)
+        self.app.core.disable_automatic_fields(layer)
 
         csv_path = get_test_path('csv/puntos_fixed_v296.csv')
         txt_delimiter = ';'

--- a/asistente_ladm_col/tests/test_integration_supplies_model.py
+++ b/asistente_ladm_col/tests/test_integration_supplies_model.py
@@ -9,6 +9,7 @@ from asistente_ladm_col.tests.utils import (get_required_fields,
                                             get_required_tables)
 from asistente_ladm_col.config.mapping_config import (ILICODE_KEY,
                                                       T_ID_KEY,
+                                                      T_ILI_TID_KEY,
                                                       DESCRIPTION_KEY,
                                                       DISPLAY_NAME_KEY)
 from asistente_ladm_col.tests.utils import (get_pg_conn,
@@ -52,8 +53,9 @@ class TestIntegrationSuppliesModel(unittest.TestCase):
         self.assertTrue(result[0], 'The test connection is not working')
 
         dict_names = self.db_pg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 40)
+        self.assertEqual(len(dict_names), 41)
         expected_dict = {T_ID_KEY: 't_id',
+                         T_ILI_TID_KEY: "t_ili_tid",
                          ILICODE_KEY: 'ilicode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispname',
@@ -73,8 +75,9 @@ class TestIntegrationSuppliesModel(unittest.TestCase):
         self.assertTrue(result[0], 'The test connection is not working')
 
         dict_names = self.db_gpkg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 40)
+        self.assertEqual(len(dict_names), 41)
         expected_dict = {T_ID_KEY: 'T_Id',
+                         T_ILI_TID_KEY: "T_Ili_Tid",
                          ILICODE_KEY: 'iliCode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispName',

--- a/asistente_ladm_col/tests/test_operation_model.py
+++ b/asistente_ladm_col/tests/test_operation_model.py
@@ -9,6 +9,7 @@ from asistente_ladm_col.tests.utils import (get_required_fields,
                                             get_required_tables)
 from asistente_ladm_col.config.mapping_config import (ILICODE_KEY,
                                                       T_ID_KEY,
+                                                      T_ILI_TID_KEY,
                                                       DESCRIPTION_KEY,
                                                       DISPLAY_NAME_KEY)
 from asistente_ladm_col.tests.utils import (get_pg_conn,
@@ -52,9 +53,10 @@ class TestOperationModel(unittest.TestCase):
         self.assertTrue(result[0], 'The test connection is not working')
 
         dict_names = self.db_pg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 144)
+        self.assertEqual(len(dict_names), 145)
 
         expected_dict = {T_ID_KEY: 't_id',
+                         T_ILI_TID_KEY: "t_ili_tid",
                          ILICODE_KEY: 'ilicode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispname',
@@ -76,9 +78,10 @@ class TestOperationModel(unittest.TestCase):
         self.assertTrue(result[0], 'The test connection is not working')
 
         dict_names = self.db_gpkg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 144)
+        self.assertEqual(len(dict_names), 145)
 
         expected_dict = {T_ID_KEY: 'T_Id',
+                         T_ILI_TID_KEY: "T_Ili_Tid",
                          ILICODE_KEY: 'iliCode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispName',

--- a/asistente_ladm_col/tests/test_reference_cartography_model.py
+++ b/asistente_ladm_col/tests/test_reference_cartography_model.py
@@ -9,6 +9,7 @@ from asistente_ladm_col.tests.utils import (get_required_fields,
                                             get_required_tables)
 from asistente_ladm_col.config.mapping_config import (ILICODE_KEY,
                                                       T_ID_KEY,
+                                                      T_ILI_TID_KEY,
                                                       DESCRIPTION_KEY,
                                                       DISPLAY_NAME_KEY)
 from asistente_ladm_col.tests.utils import (get_pg_conn,
@@ -52,9 +53,10 @@ class TestReferenceCartographyModel(unittest.TestCase):
         self.assertTrue(result[0], 'The test connection is not working')
 
         dict_names = self.db_pg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 161)
+        self.assertEqual(len(dict_names), 162)
 
         expected_dict = {T_ID_KEY: 't_id',
+                         T_ILI_TID_KEY: "t_ili_tid",
                          ILICODE_KEY: 'ilicode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispname',
@@ -76,9 +78,10 @@ class TestReferenceCartographyModel(unittest.TestCase):
         self.assertTrue(result[0], 'The test connection is not working')
 
         dict_names = self.db_gpkg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 161)
+        self.assertEqual(len(dict_names), 162)
 
         expected_dict = {T_ID_KEY: 'T_Id',
+                         T_ILI_TID_KEY: "T_Ili_Tid",
                          ILICODE_KEY: 'iliCode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispName',

--- a/asistente_ladm_col/tests/test_snr_data_model.py
+++ b/asistente_ladm_col/tests/test_snr_data_model.py
@@ -9,6 +9,7 @@ from asistente_ladm_col.tests.utils import (get_required_fields,
                                             get_required_tables)
 from asistente_ladm_col.config.mapping_config import (ILICODE_KEY,
                                                       T_ID_KEY,
+                                                      T_ILI_TID_KEY,
                                                       DESCRIPTION_KEY,
                                                       DISPLAY_NAME_KEY)
 from asistente_ladm_col.tests.utils import (get_pg_conn,
@@ -53,9 +54,10 @@ class TestSNRDataModel(unittest.TestCase):
 
 
         dict_names = self.db_pg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 15)
+        self.assertEqual(len(dict_names), 16)
 
         expected_dict = {T_ID_KEY: 't_id',
+                         T_ILI_TID_KEY: "t_ili_tid",
                          ILICODE_KEY: 'ilicode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispname',
@@ -74,9 +76,10 @@ class TestSNRDataModel(unittest.TestCase):
 
 
         dict_names = self.db_gpkg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 15)
+        self.assertEqual(len(dict_names), 16)
 
         expected_dict = {T_ID_KEY: 'T_Id',
+                         T_ILI_TID_KEY: "T_Ili_Tid",
                          ILICODE_KEY: 'iliCode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispName',

--- a/asistente_ladm_col/tests/test_valuation_model.py
+++ b/asistente_ladm_col/tests/test_valuation_model.py
@@ -9,6 +9,7 @@ from asistente_ladm_col.tests.utils import (get_required_fields,
                                             get_required_tables)
 from asistente_ladm_col.config.mapping_config import (ILICODE_KEY,
                                                       T_ID_KEY,
+                                                      T_ILI_TID_KEY,
                                                       DESCRIPTION_KEY,
                                                       DISPLAY_NAME_KEY)
 from asistente_ladm_col.tests.utils import (get_pg_conn,
@@ -52,9 +53,10 @@ class TestValuationModel(unittest.TestCase):
         self.assertTrue(result[0], 'The test connection is not working')
 
         dict_names = self.db_pg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 158)
+        self.assertEqual(len(dict_names), 159)
 
         expected_dict = {T_ID_KEY: 't_id',
+                         T_ILI_TID_KEY: "t_ili_tid",
                          ILICODE_KEY: 'ilicode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispname',
@@ -78,9 +80,10 @@ class TestValuationModel(unittest.TestCase):
         self.assertTrue(result[0], 'The test connection is not working')
 
         dict_names = self.db_gpkg.get_table_and_field_names()
-        self.assertEqual(len(dict_names), 158)
+        self.assertEqual(len(dict_names), 159)
 
         expected_dict = {T_ID_KEY: 'T_Id',
+                         T_ILI_TID_KEY: "T_Ili_Tid",
                          ILICODE_KEY: 'iliCode',
                          DESCRIPTION_KEY: 'description',
                          DISPLAY_NAME_KEY: 'dispName',

--- a/asistente_ladm_col/ui/dialogs/dlg_settings.ui
+++ b/asistente_ladm_col/ui/dialogs/dlg_settings.ui
@@ -378,113 +378,190 @@
       <attribute name="title">
        <string>Automatic Values</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_3">
+      <layout class="QGridLayout" name="gridLayout_12">
+       <item row="5" column="0">
+        <widget class="QCheckBox" name="chk_t_ili_tid">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A column that contains UUIDs identifying every object in the database. Unlike the t_id, the UUID will remain with the object after an XTF Export. Note that the UUID is not the PK.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Calculate t_ili_tid automatically</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QgsCollapsibleGroupBox" name="namespace_collapsible_group_box">
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Most of the classes in LADM_COL have two attributes that combined must be unique in the whole schema/database. They are called namespace and local_id. To make it easier to fill those attributes, the LADM_COL Assistant can set automatic values for them. Namely, namespace will correspond to an optional prefix (e.g., MY_ORGANIZATION) plus the class name (e.g., BOUNDARY): MY_ORGANIZATION_BOUNDARY.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="title">
+          <string>Calculate Namespace automatically</string>
+         </property>
+         <property name="flat">
+          <bool>true</bool>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <item>
+             <widget class="QLabel" name="label_7">
+              <property name="text">
+               <string>Prefix</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="txt_namespace">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>1</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="placeholderText">
+               <string>e.g., your organization's name</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QCheckBox" name="chk_local_id">
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;On the other hand, local_id will correspond to the id of the record in the database of the origin institution.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Calculate Local ID automatically</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
+        <spacer name="verticalSpacer_18">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="chk_automatic_values_in_batch_mode">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;For instance, when loading data from an ETL, from a CSV or from another QGIS table/layer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Calculate automatic fields when loading/importing data in batch mode</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <spacer name="verticalSpacer_15">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="10" column="0">
+        <spacer name="verticalSpacer_17">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="4" column="0">
+        <spacer name="verticalSpacer_16">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="0">
+        <spacer name="verticalSpacer_13">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
        <item row="0" column="0">
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QCheckBox" name="chk_automatic_values_in_batch_mode">
-           <property name="toolTip">
-            <string>For instance, when loading data from CSV or from another QGIS table/layer</string>
-           </property>
-           <property name="text">
-            <string>Calculate automatic fields when loading/importing data in batch mode</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="Line" name="line">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_10">
-           <property name="text">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Most of the classes in LADM_COL have two attributes that combined must be unique in the whole schema/database. They are called &lt;span style=&quot; font-weight:600;&quot;&gt;namespace&lt;/span&gt; and &lt;span style=&quot; font-weight:600;&quot;&gt;local_id&lt;/span&gt;. To make it easier to fill those attributes, the &lt;span style=&quot; font-style:italic;&quot;&gt;LADM_COL Assistant&lt;/span&gt; can set automatic values for them. &lt;/p&gt;&lt;p&gt;Namely, &lt;span style=&quot; font-weight:600;&quot;&gt;namespace&lt;/span&gt; will correspond to an optional prefix (e.g., MY_ORGANIZATION) plus the class name (e.g., BOUNDARY): MY_ORGANIZATION_BOUNDARY.&lt;/p&gt;&lt;p&gt;On the other hand, &lt;span style=&quot; font-weight:600;&quot;&gt;local_id&lt;/span&gt; will correspond to the id of the record in the database.&lt;/p&gt;&lt;p&gt;If you want to fill those values by yourself, uncheck the following checkboxes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QgsCollapsibleGroupBox" name="namespace_collapsible_group_box">
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="title">
-            <string>Calculate Namespace automatically</string>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-           <widget class="QWidget" name="layoutWidget">
-            <property name="geometry">
-             <rect>
-              <x>17</x>
-              <y>25</y>
-              <width>381</width>
-              <height>41</height>
-             </rect>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_5">
-             <item>
-              <widget class="QLabel" name="label_7">
-               <property name="text">
-                <string>Prefix</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="txt_namespace">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                 <horstretch>1</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="toolTip">
-                <string/>
-               </property>
-               <property name="placeholderText">
-                <string>e.g., your organization's name</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="chk_local_id">
-           <property name="font">
-            <font>
-             <weight>50</weight>
-             <bold>false</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Calculate Local ID automatically</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
+        <spacer name="verticalSpacer_14">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -762,16 +839,27 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>cbo_db_engine</tabstop>
-  <tabstop>btn_test_connection</tabstop>
   <tabstop>tabWidget</tabstop>
+  <tabstop>cbo_db_engine</tabstop>
+  <tabstop>btn_test_ladm_col_structure</tabstop>
+  <tabstop>btn_test_connection</tabstop>
+  <tabstop>online_models_radio_button</tabstop>
+  <tabstop>offline_models_radio_button</tabstop>
+  <tabstop>custom_model_directories_line_edit</tabstop>
+  <tabstop>custom_models_dir_button</tabstop>
+  <tabstop>chk_validate_data_importing_exporting</tabstop>
   <tabstop>chk_use_roads</tabstop>
   <tabstop>chk_automatic_values_in_batch_mode</tabstop>
+  <tabstop>chk_t_ili_tid</tabstop>
   <tabstop>namespace_collapsible_group_box</tabstop>
   <tabstop>txt_namespace</tabstop>
   <tabstop>chk_local_id</tabstop>
+  <tabstop>txt_service_transitional_system</tabstop>
+  <tabstop>btn_default_value_transitional_system</tabstop>
+  <tabstop>btn_test_service_transitional_system</tabstop>
   <tabstop>connection_box</tabstop>
   <tabstop>txt_service_endpoint</tabstop>
+  <tabstop>btn_default_value_sources</tabstop>
   <tabstop>btn_test_service</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
by letting the heavy lifting to C++

Goal:
 + ETLs running very fast.

Pending in this PR:
 + [x] Deal with t_ili_tid automatic values like other automatic values in the plugin (i.e., local_id and namespace). Disable them in batch mode if users want that. 

Pending in other PRs:
 + Use t_ili_tid for import/export operations. (Model Baker first!)
 + Add expressions for t_ili_tid in ETL models.